### PR TITLE
로그인 API 호출 로직 추가

### DIFF
--- a/src/config/ApiEndPoints.ts
+++ b/src/config/ApiEndPoints.ts
@@ -2,4 +2,5 @@ export const API_BASE_URL = 'http://localhost:3001';
 
 export const API_ENDPOINTS = {
   SIGNUP_EMAIL: `/auth/signup/email`,
+  SIGNIN_EMAIL: `/auth/signin/email`,
 };

--- a/src/features/signUp/signUpInput/Email.tsx
+++ b/src/features/signUp/signUpInput/Email.tsx
@@ -8,14 +8,20 @@ const EmailInput = styled.input<{isValid: boolean}>`
 
 const EmailContainer = styled.div`
   position: relative;
+  width: 100%;
 `;
 
 interface EmailProps {
   emailError: string;
   setEmailError: (error: string) => void;
+  showEmailErrorBorder?: boolean;
 }
 
-export default function Email({emailError, setEmailError}: EmailProps) {
+export default function Email({
+  emailError,
+  setEmailError,
+  showEmailErrorBorder = false,
+}: EmailProps) {
   const [email, setEmail] = useState('');
 
   const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -36,7 +42,7 @@ export default function Email({emailError, setEmailError}: EmailProps) {
         placeholder="이메일 (예: example@gmail.com)"
         value={email}
         onChange={handleEmailChange}
-        isValid={emailError === ''}
+        isValid={emailError === '' && !showEmailErrorBorder}
         name="email"
         type="text"
       />

--- a/src/utils/apiClient.ts
+++ b/src/utils/apiClient.ts
@@ -13,16 +13,12 @@ export default apiClient;
 
 export const postRequest = async (url: string, data: any) => {
   const token = Cookies.get('jwt');
-  try {
-    const response = await apiClient.post(url, data, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
-    return response;
-  } catch (error) {
-    throw error;
-  }
+  const response = await apiClient.post(url, data, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  return response;
 };
 
 export const formDataEntries = (event: React.FormEvent<HTMLFormElement>) => {


### PR DESCRIPTION
1. 로그인 API 연동
2. 로그인 폼 태그 유효성 검사 추가 

다음 PR 에서 Input 벨리데이션 isEmailVaild => isEmailErrroValid 로 전환 작업할 예정입니다.

<img width="717" alt="image" src="https://github.com/user-attachments/assets/64b574a1-f78b-48e0-b059-59cdccd55b40" />
